### PR TITLE
fix scatterplot layer typing

### DIFF
--- a/packages/deck.gl-layers/src/layers/scatterplot-layer.ts
+++ b/packages/deck.gl-layers/src/layers/scatterplot-layer.ts
@@ -31,7 +31,12 @@ import { validateAccessors } from "../utils/validate";
 /** All properties supported by GeoArrowScatterplotLayer */
 export type GeoArrowScatterplotLayerProps = Omit<
   ScatterplotLayerProps<arrow.RecordBatch>,
-  "data" | "getPosition" | "getRadius" | "getFillColor" | "getLineColor"
+  | "data"
+  | "getPosition"
+  | "getRadius"
+  | "getFillColor"
+  | "getLineColor"
+  | "getLineWidth"
 > &
   _GeoArrowScatterplotLayerProps &
   CompositeLayerProps;


### PR DESCRIPTION
`getLineWidth` previously had not been overridden. `getLineWidth` is a vectorized input accessor, so it should have an Arrow-based type.