### PR TITLE
chore: Relax dependency versions required by deck.gl-layers package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7064,10 +7064,10 @@
         "vitest": "^0.33.0"
       },
       "peerDependencies": {
-        "@deck.gl/aggregation-layers": "^9.2.1",
-        "@deck.gl/core": "^9.2.1",
-        "@deck.gl/geo-layers": "^9.2.1",
-        "@deck.gl/layers": "^9.2.1",
+        "@deck.gl/aggregation-layers": "^9.0.0",
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/geo-layers": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
         "@math.gl/polygon": "^4.1.0",
         "apache-arrow": ">=15"
       }

--- a/packages/deck.gl-layers/package.json
+++ b/packages/deck.gl-layers/package.json
@@ -38,10 +38,10 @@
   "author": "Kyle Barron <kylebarron2@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@deck.gl/aggregation-layers": "^9.2.1",
-    "@deck.gl/core": "^9.2.1",
-    "@deck.gl/geo-layers": "^9.2.1",
-    "@deck.gl/layers": "^9.2.1",
+    "@deck.gl/aggregation-layers": "^9.0.0",
+    "@deck.gl/core": "^9.0.0",
+    "@deck.gl/geo-layers": "^9.0.0",
+    "@deck.gl/layers": "^9.0.0",
     "@math.gl/polygon": "^4.1.0",
     "apache-arrow": ">=15"
   },


### PR DESCRIPTION
Closes https://github.com/geoarrow/deck.gl-layers/issues/153