### PR TITLE
ci: Don't publish npm package with beta string as latest tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,14 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
-      - run: cd packages/deck.gl-layers && npm publish
+      - name: Read version and publish
+        run: |
+          VERSION=$(jq -r .version package.json)
+          if [[ "$VERSION" == *alpha* || "$VERSION" == *beta* ]]; then
+            npm publish --tag beta
+          else
+            npm publish
+          fi
+        working-directory: packages/deck.gl-layers
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
It's really annoying that `npm publish` always publishes a package with the "latest" tag by default, so if you `npm publish` where the version is `0.4.0-beta.1`, then anyone who runs `npm install` on your package will get _that version_ instead of `0.3.x`.

This changes the release script to check if there's `alpha` or `beta` in the tag, and then publish it by a different tag name.