### PR TITLE
fix: Define attributes object if not already defined

### DIFF
--- a/packages/deck.gl-layers/src/utils/utils.ts
+++ b/packages/deck.gl-layers/src/utils/utils.ts
@@ -255,6 +255,8 @@ export function assignAccessor(args: AssignAccessorProps) {
     return;
   }
 
+  props.data.attributes = props.data.attributes || {};
+
   if (propInput instanceof arrow.Data) {
     const columnData = propInput;
 


### PR DESCRIPTION
I hit this in the H3HexagonLayer, because that's the only layer (so far) that doesn't directly define an `attributes` object in the layer