### PR TITLE
update package-lock.json, resolve arrows layer with explicit file path, fix #183

### DIFF
--- a/examples/linestring/package.json
+++ b/examples/linestring/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@geoarrow/deck.gl-layers": "*",
+    "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
     "apache-arrow": ">=14",
     "deck.gl": "^9.2.1",
     "react": "^18.0.0",

--- a/examples/multipoint/package.json
+++ b/examples/multipoint/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@geoarrow/deck.gl-layers": "*",
+    "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
     "apache-arrow": ">=14",
     "deck.gl": "^9.2.1",
     "react": "^18.0.0",

--- a/examples/multipolygon/package.json
+++ b/examples/multipolygon/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@geoarrow/deck.gl-layers": "*",
+    "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
     "apache-arrow": ">=14",
     "deck.gl": "^9.2.1",
     "react": "^18.0.0",

--- a/examples/point/package.json
+++ b/examples/point/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@geoarrow/deck.gl-layers": "*",
+    "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
     "@loaders.gl/compression": "^4.1.4",
     "@loaders.gl/crypto": "^4.1.4",
     "apache-arrow": ">=14",

--- a/examples/polygon/package.json
+++ b/examples/polygon/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@geoarrow/deck.gl-layers": "*",
+    "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
     "apache-arrow": ">=14",
     "deck.gl": "^9.2.1",
     "react": "^18.0.0",

--- a/examples/text/package.json
+++ b/examples/text/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@geoarrow/deck.gl-layers": "*",
+    "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
     "apache-arrow": ">=14",
     "deck.gl": "^9.2.1",
     "react": "^18.0.0",

--- a/examples/trips/package.json
+++ b/examples/trips/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@geoarrow/deck.gl-layers": "*",
+    "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
     "apache-arrow": ">=14",
     "deck.gl": "^9.2.1",
     "react": "^18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geoarrow/deck.gl-layers": "*",
+        "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
         "apache-arrow": ">=14",
         "deck.gl": "^9.2.1",
         "react": "^18.0.0",
@@ -43,10 +43,6 @@
         "@types/react-dom": "^18.0.0",
         "vite": "^4.0.0"
       }
-    },
-    "examples/linestring/node_modules/@geoarrow/deck.gl-layers": {
-      "resolved": "",
-      "link": true
     },
     "examples/multilinestring": {
       "name": "deckgl-example-geoarrow-multilinestring-layer",
@@ -70,7 +66,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geoarrow/deck.gl-layers": "*",
+        "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
         "apache-arrow": ">=14",
         "deck.gl": "^9.2.1",
         "react": "^18.0.0",
@@ -88,7 +84,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geoarrow/deck.gl-layers": "*",
+        "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
         "apache-arrow": ">=14",
         "deck.gl": "^9.2.1",
         "react": "^18.0.0",
@@ -101,16 +97,12 @@
         "vite": "^4.0.0"
       }
     },
-    "examples/multipolygon/node_modules/@geoarrow/deck.gl-layers": {
-      "resolved": "",
-      "link": true
-    },
     "examples/point": {
       "name": "deckgl-example-geoarrow-point-layer",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geoarrow/deck.gl-layers": "*",
+        "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
         "@loaders.gl/compression": "^4.1.4",
         "@loaders.gl/crypto": "^4.1.4",
         "apache-arrow": ">=14",
@@ -684,7 +676,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geoarrow/deck.gl-layers": "*",
+        "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
         "apache-arrow": ">=14",
         "deck.gl": "^9.2.1",
         "react": "^18.0.0",
@@ -696,17 +688,13 @@
         "@types/react-dom": "^18.0.0",
         "vite": "^4.0.0"
       }
-    },
-    "examples/polygon/node_modules/@geoarrow/deck.gl-layers": {
-      "resolved": "",
-      "link": true
     },
     "examples/text": {
       "name": "deckgl-example-geoarrow-text-layer",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geoarrow/deck.gl-layers": "*",
+        "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
         "apache-arrow": ">=14",
         "deck.gl": "^9.2.1",
         "react": "^18.0.0",
@@ -718,17 +706,13 @@
         "@types/react-dom": "^18.0.0",
         "vite": "^4.0.0"
       }
-    },
-    "examples/text/node_modules/@geoarrow/deck.gl-layers": {
-      "resolved": "",
-      "link": true
     },
     "examples/trips": {
       "name": "deckgl-example-geoarrow-trips-layer",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geoarrow/deck.gl-layers": "*",
+        "@geoarrow/deck.gl-layers": "file:../../packages/deck.gl-layers",
         "apache-arrow": ">=14",
         "deck.gl": "^9.2.1",
         "react": "^18.0.0",
@@ -740,10 +724,6 @@
         "@types/react-dom": "^18.0.0",
         "vite": "^4.0.0"
       }
-    },
-    "examples/trips/node_modules/@geoarrow/deck.gl-layers": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/@arcgis/core": {
       "version": "4.33.14",
@@ -3045,15 +3025,15 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.26",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
-      "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
@@ -3896,9 +3876,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -7036,7 +7016,7 @@
     },
     "packages/deck.gl-layers": {
       "name": "@geoarrow/deck.gl-layers",
-      "version": "0.4.0-beta.5",
+      "version": "0.4.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@geoarrow/geoarrow-js": "^0.3.0",


### PR DESCRIPTION
Note: this doesn't actually mean that I'm seeing correct results when running an example, but that seems to be separate and this at least means I can start debugging that.

# According to Cursor which I used to make these changes:

Volta does what it says on the tin: everyone uses the same Node and npm, so installs are reproducible in the sense of “same tool versions.” It does not guarantee a good `package-lock.json`: whatever is committed (including incomplete or npm-version-specific quirks) is what everyone gets.

What went wrong here wasn’t “random drift,” it was deterministic bad metadata:

The lockfile listed nested installs like `examples/polygon/node_modules/@geoarrow/deck.gl-layers` with `"resolved": ""` and `"link": true`. With that empty resolved, npm still created a symlink, but it resolved to the wrong place (the monorepo root), so Node/Vite read deck.gl-layers-monorepo’s package.json instead of packages/deck.gl-layers. That’s a broken link, not a subtle semver difference.

Why it might have “worked before” in someone’s memory:

- No nested @geoarrow folder: some examples never had examples/…/node_modules/@geoarrow/deck.gl-layers, so resolution walked up to node_modules/@geoarrow/deck.gl-layers (correct). Others only broke when a nested link appeared.
- Different lockfile / install path: an older npm install might have hoisted differently or written different packages entries, until a later install or lockfile merge introduced the resolved: "" stubs.
npm behavior: workspace + * + how nested links are recorded has changed across npm majors; a lock produced under one npm can look “fine” until someone regenerates or edits dependencies and npm rewrites those sections.

So the change was necessary because we needed explicit, unambiguous wiring (file:../../packages/deck.gl-layers) and lockfile entries that don’t point to an empty resolved, so npm doesn’t recreate the bad symlink. Volta keeps which npm runs; it doesn’t fix a bad lockfile graph by itself.
Short summary: Past success was likely layout-dependent (hoisting vs nested node_modules) or lockfile-dependent. Pinning Node/npm with Volta doesn’t override bad resolved data for workspace links—that’s why the explicit file: + corrected lockfile mattered.