### PR TITLE
Update README with build instructions for POINT example

### DIFF
--- a/examples/point/README.md
+++ b/examples/point/README.md
@@ -36,6 +36,11 @@ Then build the package so it can be imported in the examples.
 pnpm build
 ```
 
+You can also build the source in watch mode if you'd like to edit deck.gl-geoarrow source code:
+
+```
+pnpm build:watch
+```
 Then from this directory:
 
 - `pnpm dev` — start the dev server (http://localhost:3000) with hot reload

--- a/examples/point/README.md
+++ b/examples/point/README.md
@@ -31,6 +31,11 @@ From the repository root, install dependencies once:
 pnpm install
 ```
 
+Then build the package so it can be imported in the examples.
+```
+pnpm build
+```
+
 Then from this directory:
 
 - `pnpm dev` — start the dev server (http://localhost:3000) with hot reload


### PR DESCRIPTION
Thank you for your great work on geoarrow.

I wanted to run the point example but I found that the instructions are they are listed did not work for me.  I got this error from a fresh install.

```
8:12:32 PM [vite] (client) Pre-transform error: Failed to resolve import "@geoarrow/deck.gl-geoarrow" from "src/App.tsx". Does the file exist?
  Plugin: vite:import-analysis
  File: /Users/cloftus/github/deck.gl-geoarrow/examples/point/src/App.tsx:4:41
  1  |  import { MapboxOverlay } from "@deck.gl/mapbox";
  2  |  import { GeoArrowScatterplotLayer } from "@geoarrow/deck.gl-geoarrow";
     |                                            ^
  3  |  import * as arrow from "apache-arrow";
  4  |  import "maplibre-gl/dist/maplibre-gl.css";
```

However, once I ran `pnpm build` it did work. 

Feel free to close if this is not an error and just a misunderstanding on my part.

Thanks!