### PR TITLE
chore: Export types from types.ts through top-level package

### DIFF
--- a/packages/deck.gl-geoarrow/src/index.ts
+++ b/packages/deck.gl-geoarrow/src/index.ts
@@ -47,4 +47,12 @@ export { GeoArrowTextLayer as _GeoArrowTextLayer } from "./layers/text-layer.js"
 export type { GeoArrowTripsLayerProps } from "./layers/trips-layer.js";
 export { GeoArrowTripsLayer } from "./layers/trips-layer.js";
 
-export type { GeoArrowPickingInfo } from "./types.js";
+export type {
+  Accessor,
+  AccessorFunction,
+  ColorAccessor,
+  FloatAccessor,
+  GeoArrowPickingInfo,
+  NormalAccessor,
+  TimestampAccessor,
+} from "./types.js";

--- a/packages/deck.gl-geoarrow/src/types.ts
+++ b/packages/deck.gl-geoarrow/src/types.ts
@@ -6,16 +6,16 @@ import type { BinaryAttribute, Color, PickingInfo } from "@deck.gl/core";
 import type * as arrow from "apache-arrow";
 import type { Data } from "apache-arrow";
 
-type TypedArray =
-  | Int8Array
-  | Uint8Array
-  | Uint8ClampedArray
-  | Int16Array
-  | Uint16Array
-  | Int32Array
-  | Uint32Array
+export type TypedArray =
   | Float32Array
-  | Float64Array;
+  | Float64Array
+  | Int16Array
+  | Int32Array
+  | Int8Array
+  | Uint16Array
+  | Uint32Array
+  | Uint8Array
+  | Uint8ClampedArray;
 
 /**
  * An individual layer's data

--- a/packages/deck.gl-geoarrow/src/utils/utils.ts
+++ b/packages/deck.gl-geoarrow/src/utils/utils.ts
@@ -9,18 +9,8 @@ import type {
   _InternalAccessorContext,
   AccessorContext,
   AccessorFunction,
+  TypedArray,
 } from "../types";
-
-export type TypedArray =
-  | Uint8Array
-  | Uint8ClampedArray
-  | Uint16Array
-  | Uint32Array
-  | Int8Array
-  | Int16Array
-  | Int32Array
-  | Float32Array
-  | Float64Array;
 
 export function findGeometryColumnIndex(
   schema: arrow.Schema,


### PR DESCRIPTION
Previously lonboard had been importing from the internal `types.ts` file, which no longer works with our new publishing structure.