### PR TITLE
fix: Extends object = object instead of never

### DIFF
--- a/packages/deck.gl-geoarrow/src/layers/a5-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/a5-layer.ts
@@ -99,7 +99,7 @@ const defaultProps: DefaultProps<GeoArrowA5LayerProps> = {
 };
 
 export class GeoArrowA5Layer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowA5LayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowA5Layer";

--- a/packages/deck.gl-geoarrow/src/layers/arc-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/arc-layer.ts
@@ -116,7 +116,7 @@ const defaultProps: DefaultProps<GeoArrowArcLayerProps> = {
 };
 
 export class GeoArrowArcLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowArcLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowArcLayer";

--- a/packages/deck.gl-geoarrow/src/layers/column-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/column-layer.ts
@@ -110,7 +110,7 @@ const defaultProps: DefaultProps<GeoArrowColumnLayerProps> = {
  * coordinates.
  */
 export class GeoArrowColumnLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowColumnLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowColumnLayer";

--- a/packages/deck.gl-geoarrow/src/layers/geohash-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/geohash-layer.ts
@@ -95,7 +95,7 @@ const defaultProps: DefaultProps<GeoArrowGeohashLayerProps> = {
 };
 
 export class GeoArrowGeohashLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowGeohashLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowGeohashLayer";

--- a/packages/deck.gl-geoarrow/src/layers/h3-hexagon-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/h3-hexagon-layer.ts
@@ -99,7 +99,7 @@ const defaultProps: DefaultProps<GeoArrowH3HexagonLayerProps> = {
 };
 
 export class GeoArrowH3HexagonLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowH3HexagonLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowH3HexagonLayer";

--- a/packages/deck.gl-geoarrow/src/layers/heatmap-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/heatmap-layer.ts
@@ -76,7 +76,7 @@ const defaultProps: DefaultProps<GeoArrowHeatmapLayerProps> = {
 };
 
 export class GeoArrowHeatmapLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowHeatmapLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowHeatmapLayer";

--- a/packages/deck.gl-geoarrow/src/layers/path-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/path-layer.ts
@@ -94,7 +94,7 @@ export const defaultProps: DefaultProps<GeoArrowPathLayerProps> = {
  * Render lists of coordinate points as extruded polylines with mitering.
  */
 export class GeoArrowPathLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowPathLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowPathLayer";

--- a/packages/deck.gl-geoarrow/src/layers/point-cloud-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/point-cloud-layer.ts
@@ -89,7 +89,7 @@ const defaultProps: DefaultProps<GeoArrowPointCloudLayerProps> = {
 };
 
 export class GeoArrowPointCloudLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowPointCloudLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowPointCloudLayer";

--- a/packages/deck.gl-geoarrow/src/layers/polygon-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/polygon-layer.ts
@@ -210,7 +210,7 @@ const defaultLineColor: [number, number, number, number] = [0, 0, 0, 255];
  * GeoArrowSolidPolygonLayer and the GeoArrowPathLayer.
  */
 export class GeoArrowPolygonLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<Required<GeoArrowPolygonLayerProps> & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowPolygonLayer";

--- a/packages/deck.gl-geoarrow/src/layers/s2-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/s2-layer.ts
@@ -95,7 +95,7 @@ const defaultProps: DefaultProps<GeoArrowS2LayerProps> = {
 };
 
 export class GeoArrowS2Layer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowS2LayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowS2Layer";

--- a/packages/deck.gl-geoarrow/src/layers/scatterplot-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/scatterplot-layer.ts
@@ -101,7 +101,7 @@ const defaultProps: DefaultProps<GeoArrowScatterplotLayerProps> = {
 };
 
 export class GeoArrowScatterplotLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowScatterplotLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowScatterplotLayer";

--- a/packages/deck.gl-geoarrow/src/layers/solid-polygon-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/solid-polygon-layer.ts
@@ -189,7 +189,7 @@ const defaultProps: DefaultProps<GeoArrowSolidPolygonLayerProps> = {
 };
 
 export class GeoArrowSolidPolygonLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowSolidPolygonLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowSolidPolygonLayer";

--- a/packages/deck.gl-geoarrow/src/layers/text-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/text-layer.ts
@@ -148,7 +148,7 @@ const defaultProps: DefaultProps<GeoArrowTextLayerProps> = {
 };
 
 export class GeoArrowTextLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowTextLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowTextLayer";

--- a/packages/deck.gl-geoarrow/src/layers/trips-layer.ts
+++ b/packages/deck.gl-geoarrow/src/layers/trips-layer.ts
@@ -89,7 +89,7 @@ const defaultProps: DefaultProps<GeoArrowTripsLayerProps> = {
 
 /** Render animated paths that represent vehicle trips. */
 export class GeoArrowTripsLayer<
-  ExtraProps extends object = Record<string, never>,
+  ExtraProps extends object = object,
 > extends CompositeLayer<GeoArrowTripsLayerProps & ExtraProps> {
   static override defaultProps = defaultProps;
   static override layerName = "GeoArrowTripsLayer";


### PR DESCRIPTION
Downstream when upgrading lonboard to 0.4 I got typescript lint errors. Upstream deck.gl uses `extends {} = {}` but biome [disallows that](https://biomejs.dev/linter/rules/no-banned-types/).

We can use `object` instead of `{}`